### PR TITLE
implement DynSized properly to support dyn_sized v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/mikeyhew/thin-rs"
 
 [dependencies]
-dyn_sized = "^0.1"
+dyn_sized =  { path = "../dyn_sized" }
 fn_move = "^0.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub extern crate dyn_sized;
 extern crate fn_move;
 extern crate alloc;
 
-pub use dyn_sized::{DynSized, AssembleSafe};
+pub use dyn_sized::DynSized;
 pub use fn_move::FnMove;
 
 mod backend;


### PR DESCRIPTION
- changes `<Thinbackend<D,D> as DynSized>::Meta` from `()` to `D::Meta`
- adds `ThinBackend::fat_from_thin` and `fat_from_thin_mut` to do what `assemble` did before